### PR TITLE
Add expandable price history panel with stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,10 +122,31 @@
     background:color-mix(in oklab,#ff8d7a 18%, transparent)}
   .badge.delta.flat{color:var(--muted);border-color:color-mix(in oklab, var(--gold) 25%, transparent);
     background:color-mix(in oklab, var(--bg) 86%, transparent)}
-  .sparkline-wrap{display:flex;align-items:center;gap:10px;margin-top:10px;flex-wrap:wrap}
-  .sparkline-box{flex:1 1 220px;min-height:60px;padding:6px 8px;border-radius:12px;background:color-mix(in oklab, var(--bg) 82%, transparent);
+  .history-toggle-bar{display:flex;justify-content:flex-end;margin-top:12px}
+  .history-toggle-bar .btn-mini{font-weight:600}
+  .history-section{margin-top:12px;display:flex;flex-direction:column;gap:12px}
+  .history-header{display:flex;align-items:center;gap:10px;flex-wrap:wrap;justify-content:space-between}
+  .history-badge{display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+  .history-label-sep{opacity:.45}
+  .history-range{font-weight:700}
+  .history-tabs{display:flex;gap:6px;flex-wrap:wrap}
+  .history-tab{border:1px solid color-mix(in oklab, var(--gold) 30%, transparent);background:color-mix(in oklab, var(--bg) 82%, transparent);
+    color:var(--ink);border-radius:10px;padding:6px 12px;cursor:pointer;font-size:12px;transition:.2s}
+  .history-tab:focus{outline:none;box-shadow:var(--outline)}
+  .history-tab.active{background:linear-gradient(135deg,var(--gold),var(--gold2));color:var(--accent-ink);border-color:transparent;
+    box-shadow:0 6px 16px color-mix(in oklab, var(--gold) 28%, transparent)}
+  .history-chart{padding:12px 14px;border-radius:12px;background:color-mix(in oklab, var(--bg) 82%, transparent);
     border:1px solid color-mix(in oklab, var(--gold) 22%, transparent)}
-  .sparkline-box canvas{width:100%;height:48px;display:block}
+  .history-chart canvas{width:100%;height:120px;display:block}
+  .history-empty{font-size:12px;color:var(--muted);}
+  .history-stats{display:grid;gap:8px;grid-template-columns:repeat(auto-fit,minmax(140px,1fr))}
+  .history-stat{padding:10px 12px;border-radius:12px;background:color-mix(in oklab, var(--bg) 88%, transparent);
+    border:1px solid color-mix(in oklab, var(--gold) 18%, transparent);font-size:12px}
+  .history-stat strong{display:block;margin-top:4px;font-size:16px;font-weight:700;direction:ltr;text-align:left}
+  .history-change{font-weight:700}
+  .history-change.positive{color:#33d69f}
+  .history-change.negative{color:#ff8d7a}
+  .history-change.flat{color:var(--muted)}
   .out{font-family:ui-monospace,Menlo,Consolas,monospace;line-height:1.6;background:color-mix(in oklab, var(--bg) 82%, transparent);
     border:1px solid color-mix(in oklab, var(--gold) 22%, transparent);padding:12px;border-radius:12px}
   .error{background:#3a120c;border:1px solid rgba(255,150,120,.6);color:#ffe1db;padding:10px;border-radius:10px;font-size:12px}
@@ -348,10 +369,56 @@
         <span class="spacer"></span>
       </div>
 
-      <div class="sparkline-wrap">
-        <span class="badge" data-i18n="sparkline_label">منحنى السعر (آخر 50 تحديثًا)</span>
-        <div class="sparkline-box">
-          <canvas id="priceSparkline" height="48" role="img" data-i18n-title="sparkline_empty" title="—"></canvas>
+      <div class="history-toggle-bar">
+        <button id="historyToggle" class="btn-mini" type="button" aria-expanded="false" aria-controls="historySection">
+          <span data-i18n="history_toggle_show">عرض سجل السعر</span>
+        </button>
+      </div>
+
+      <div class="history-section" id="historySection" hidden aria-hidden="true">
+        <div class="history-header">
+          <span class="badge history-badge" id="historyLabel">
+            <span data-i18n="history_label_base">منحنى السعر</span>
+            <span class="history-label-sep">•</span>
+            <span class="history-range" id="historyRangeText">—</span>
+          </span>
+          <div class="history-tabs" role="group" data-i18n-aria="history_tabs_label">
+            <button type="button" class="history-tab" data-history-range="1h" data-i18n="history_tab_1h" aria-pressed="false">١س</button>
+            <button type="button" class="history-tab" data-history-range="6h" data-i18n="history_tab_6h" aria-pressed="false">٦س</button>
+            <button type="button" class="history-tab" data-history-range="24h" data-i18n="history_tab_24h" aria-pressed="false">٢٤س</button>
+            <button type="button" class="history-tab" data-history-range="all" data-i18n="history_tab_all" aria-pressed="false">الكل</button>
+          </div>
+        </div>
+
+        <div class="history-chart">
+          <canvas id="priceSparkline" height="120" role="img" data-i18n-title="history_empty" title="—"></canvas>
+        </div>
+        <div id="historyEmpty" class="history-empty" hidden>—</div>
+        <div class="history-stats" id="historyStats">
+          <div class="history-stat">
+            <span class="history-stat-label" data-i18n="history_stat_high">أعلى</span>
+            <strong id="historyHigh">—</strong>
+          </div>
+          <div class="history-stat">
+            <span class="history-stat-label" data-i18n="history_stat_low">أدنى</span>
+            <strong id="historyLow">—</strong>
+          </div>
+          <div class="history-stat">
+            <span class="history-stat-label" data-i18n="history_stat_avg">متوسط</span>
+            <strong id="historyAvg">—</strong>
+          </div>
+          <div class="history-stat">
+            <span class="history-stat-label" data-i18n="history_stat_change">التغير</span>
+            <strong id="historyChange" class="history-change">—</strong>
+          </div>
+          <div class="history-stat">
+            <span class="history-stat-label" data-i18n="history_stat_samples">القراءات</span>
+            <strong id="historySamples">—</strong>
+          </div>
+          <div class="history-stat">
+            <span class="history-stat-label" data-i18n="history_stat_updated">آخر قراءة</span>
+            <strong id="historyLastTime">—</strong>
+          </div>
         </div>
       </div>
 
@@ -612,6 +679,29 @@
       sparkline_label:"منحنى السعر (آخر 50 تحديثًا)",
       sparkline_hint:"آخر {n} أسعار. أحدث قيمة: {p} دولار/أونصة.",
       sparkline_empty:"لم يتم جمع بيانات بعد.",
+      history_label_base:"منحنى السعر",
+      history_tabs_label:"نطاق عرض سجل السعر",
+      history_tab_1h:"١س",
+      history_tab_6h:"٦س",
+      history_tab_24h:"٢٤س",
+      history_tab_all:"الكل",
+      history_range_1h:"آخر ساعة",
+      history_range_6h:"آخر ٦ ساعات",
+      history_range_24h:"آخر ٢٤ ساعة",
+      history_range_all:"كل القراءات",
+      history_hint:"عدد القراءات: {n} • أحدث قيمة: {p} دولار/أونصة.",
+      history_empty:"لا بيانات ضمن {range}.",
+      history_stat_high:"أعلى",
+      history_stat_low:"أدنى",
+      history_stat_avg:"متوسط",
+      history_stat_change:"التغير",
+      history_stat_samples:"القراءات",
+      history_stat_updated:"آخر قراءة",
+      history_change_positive:"↑ +$ {amount} ({pct}٪)",
+      history_change_negative:"↓ −$ {amount} ({pct}٪)",
+      history_change_flat:"↔ $0 (0٪)",
+      history_toggle_show:"عرض سجل السعر",
+      history_toggle_hide:"إخفاء سجل السعر",
 
       h_basic:"الأسعار الأساسية من دون صياغة (دولار/غرام)",
       sell18:"مبيع 18K", buy18:"شراء 18K", sell21:"مبيع 21K", buy21:"شراء 21K", per_g:"/ غ",
@@ -700,6 +790,29 @@
       sparkline_label:"Price trend (last 50 updates)",
       sparkline_hint:"Last {n} prices. Latest: {p} USD/oz.",
       sparkline_empty:"No recent data yet.",
+      history_label_base:"Price history",
+      history_tabs_label:"Select price history range",
+      history_tab_1h:"1h",
+      history_tab_6h:"6h",
+      history_tab_24h:"24h",
+      history_tab_all:"All",
+      history_range_1h:"Last hour",
+      history_range_6h:"Last 6 hours",
+      history_range_24h:"Last 24 hours",
+      history_range_all:"All saved readings",
+      history_hint:"Samples: {n} • Latest: {p} USD/oz.",
+      history_empty:"No data inside {range} yet.",
+      history_stat_high:"High",
+      history_stat_low:"Low",
+      history_stat_avg:"Average",
+      history_stat_change:"Change",
+      history_stat_samples:"Samples",
+      history_stat_updated:"Last reading",
+      history_change_positive:"↑ +$ {amount} ({pct}%)",
+      history_change_negative:"↓ −$ {amount} ({pct}%)",
+      history_change_flat:"↔ $0 (0%)",
+      history_toggle_show:"Show price history",
+      history_toggle_hide:"Hide price history",
 
       h_basic:"Base prices without making (USD/gram)",
       sell18:"Sell 18K", buy18:"Buy 18K", sell21:"Sell 21K", buy21:"Buy 21K", per_g:"/ g",
@@ -807,6 +920,7 @@
 
     document.title = t("page_title");
 
+    applyHistoryVisibility();
     setLastUpdated();
     renderFormulas();
     renderSparkline();
@@ -896,6 +1010,8 @@
   const CFG_KEY = "gold_cfg_v1";
   const SPOT_KEY = "last_spot_v1";
   const PRICE_HISTORY_KEY = "price_history_v1";
+  const HISTORY_VISIBILITY_KEY = "price_history_visible_v1";
+  const HISTORY_WINDOW_KEY = "price_history_window_v1";
   const DEFAULTS = Object.freeze({
     oztToG: 32,
     autoRefreshSec: 10,
@@ -1193,9 +1309,35 @@
   let nextRateLimitCooldownMs = RATE_LIMIT_MIN_COOLDOWN_MS;
   let cooldownUntil = 0;
   let rateLimitStrikeCount = 0;
-  const PRICE_HISTORY_LIMIT = 50;
+  const PRICE_HISTORY_LIMIT = 20000;
   const PRICE_DELTA_EPS = 0.05;
   let priceHistory = loadPriceHistory();
+
+  const HISTORY_WINDOWS = [
+    { id:"1h",  durationMs: 1 * 60 * 60 * 1000,  labelKey:"history_range_1h" },
+    { id:"6h",  durationMs: 6 * 60 * 60 * 1000,  labelKey:"history_range_6h" },
+    { id:"24h", durationMs: 24 * 60 * 60 * 1000, labelKey:"history_range_24h" },
+    { id:"all", durationMs: Infinity,            labelKey:"history_range_all" }
+  ];
+  const HISTORY_DEFAULT_ID = "6h";
+  const historySectionEl = $("historySection");
+  const historyToggleBtn = $("historyToggle");
+  let historyWindowId = HISTORY_DEFAULT_ID;
+  let historyVisible = false;
+
+  (function restoreHistoryPrefs(){
+    try{
+      const savedWindow = localStorage.getItem(HISTORY_WINDOW_KEY);
+      if(savedWindow && HISTORY_WINDOWS.some(win => win.id === savedWindow)){
+        historyWindowId = savedWindow;
+      }
+    }catch{}
+    try{
+      const savedVisibility = localStorage.getItem(HISTORY_VISIBILITY_KEY);
+      if(savedVisibility === "1") historyVisible = true;
+    }catch{}
+  })();
+  applyHistoryVisibility();
 
   function inRateLimitCooldown(){
     return cooldownUntil && Date.now() < cooldownUntil;
@@ -1318,23 +1460,171 @@
     }
   }
 
+  function getHistoryWindowById(id){
+    return HISTORY_WINDOWS.find(win => win.id === id) || null;
+  }
+
+  function getActiveHistoryWindow(){
+    return getHistoryWindowById(historyWindowId) || HISTORY_WINDOWS[0] || null;
+  }
+
+  function filterHistoryByWindow(win){
+    if(!win) return priceHistory.slice();
+    if(!isFinite(win.durationMs)) return priceHistory.slice();
+    const cutoff = Date.now() - win.durationMs;
+    return priceHistory.filter(pt => pt && isFinite(pt.t) && pt.t >= cutoff);
+  }
+
+  function updateHistoryTabs(){
+    const current = getActiveHistoryWindow();
+    const rangeLabelRaw = current ? t(current.labelKey) : "";
+    const rangeLabel = rangeLabelRaw || t("history_range_all");
+    const rangeEl = $("historyRangeText");
+    if(rangeEl) rangeEl.textContent = rangeLabel;
+    document.querySelectorAll(".history-tab").forEach(btn => {
+      const id = btn.getAttribute("data-history-range");
+      const isActive = !!current && id === current.id;
+      btn.classList.toggle("active", isActive);
+      btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+    });
+    return { current, rangeLabel };
+  }
+
+  function applyHistoryVisibility(){
+    const label = t(historyVisible ? "history_toggle_hide" : "history_toggle_show");
+    if(historyToggleBtn){
+      historyToggleBtn.textContent = label;
+      historyToggleBtn.setAttribute("aria-label", label);
+      historyToggleBtn.setAttribute("aria-expanded", historyVisible ? "true" : "false");
+      historyToggleBtn.setAttribute("aria-pressed", historyVisible ? "true" : "false");
+    }
+    if(historySectionEl){
+      historySectionEl.hidden = !historyVisible;
+      historySectionEl.setAttribute("aria-hidden", historyVisible ? "false" : "true");
+    }
+  }
+
+  function updateHistoryStats(valid){
+    const highEl = $("historyHigh");
+    const lowEl = $("historyLow");
+    const avgEl = $("historyAvg");
+    const changeEl = $("historyChange");
+    const samplesEl = $("historySamples");
+    const lastEl = $("historyLastTime");
+
+    const reset = () => {
+      if(highEl) highEl.textContent = "—";
+      if(lowEl) lowEl.textContent = "—";
+      if(avgEl) avgEl.textContent = "—";
+      if(samplesEl) samplesEl.textContent = "—";
+      if(lastEl) lastEl.textContent = "—";
+      if(changeEl){
+        changeEl.textContent = "—";
+        changeEl.classList.remove("positive","negative","flat");
+      }
+    };
+
+    if(!Array.isArray(valid) || !valid.length){
+      reset();
+      return;
+    }
+
+    const prices = valid.map(pt => Number(pt && pt.p)).filter(p => isFinite(p));
+    if(!prices.length){
+      reset();
+      return;
+    }
+
+    const high = Math.max(...prices);
+    const low = Math.min(...prices);
+    const avg = prices.reduce((sum,val)=>sum+val,0) / prices.length;
+    const first = prices[0];
+    const last = prices[prices.length - 1];
+    const diff = last - first;
+    const pct = isFinite(first) && Math.abs(first) > 0.0001 ? (diff / first) * 100 : 0;
+
+    if(highEl) highEl.textContent = fmtFixed(high);
+    if(lowEl) lowEl.textContent = fmtFixed(low);
+    if(avgEl) avgEl.textContent = fmtFixed(avg);
+    if(samplesEl) samplesEl.textContent = prices.length.toLocaleString();
+    if(lastEl){
+      const lastPoint = valid[valid.length - 1];
+      const ts = Number(lastPoint && lastPoint.t);
+      lastEl.textContent = isFinite(ts) ? fmtDateTime(new Date(ts)) : "—";
+    }
+
+    if(changeEl){
+      changeEl.classList.remove("positive","negative","flat");
+      if(Math.abs(diff) < PRICE_DELTA_EPS){
+        changeEl.textContent = t("history_change_flat");
+        changeEl.classList.add("flat");
+      }else if(diff > 0){
+        changeEl.textContent = t("history_change_positive", {
+          amount: fmtFixed(Math.abs(diff)),
+          pct: Math.abs(pct).toLocaleString(undefined,{maximumFractionDigits:2})
+        });
+        changeEl.classList.add("positive");
+      }else{
+        changeEl.textContent = t("history_change_negative", {
+          amount: fmtFixed(Math.abs(diff)),
+          pct: Math.abs(pct).toLocaleString(undefined,{maximumFractionDigits:2})
+        });
+        changeEl.classList.add("negative");
+      }
+    }
+  }
+
   function renderSparkline(){
     const canvas = $("priceSparkline");
     if(!canvas) return;
 
-    const valid = priceHistory.filter(pt => pt && isFinite(pt.p));
-    const labelBase = t("sparkline_label");
+    const { current, rangeLabel } = updateHistoryTabs();
+    const filtered = filterHistoryByWindow(current)
+      .slice()
+      .sort((a,b) => a.t - b.t);
+    const valid = filtered.filter(pt => pt && isFinite(pt.p));
+    const labelBase = t("history_label_base");
+    const emptyText = t("history_empty", { range: rangeLabel });
+
+    const emptyEl = $("historyEmpty");
     if(!valid.length){
-      const emptyText = t("sparkline_empty");
       canvas.title = emptyText;
       canvas.setAttribute("aria-label", labelBase + ": " + emptyText);
-    }else{
-      const latest = valid[valid.length - 1];
-      const infoText = t("sparkline_hint")
-        .replace("{n}", valid.length)
-        .replace("{p}", fmt(latest.p));
-      canvas.title = infoText;
-      canvas.setAttribute("aria-label", labelBase + ": " + infoText);
+      if(emptyEl){
+        emptyEl.hidden = false;
+        emptyEl.textContent = emptyText;
+      }
+      updateHistoryStats(valid);
+      const ctx = canvas.getContext("2d");
+      if(ctx) ctx.clearRect(0, 0, canvas.width || 0, canvas.height || 0);
+      return;
+    }
+
+    if(emptyEl) emptyEl.hidden = true;
+    updateHistoryStats(valid);
+
+    const latest = valid[valid.length - 1];
+    const infoText = t("history_hint", {
+      n: valid.length.toLocaleString(),
+      p: fmt(latest.p)
+    });
+    canvas.title = infoText;
+    canvas.setAttribute("aria-label", labelBase + ": " + infoText);
+
+    if(historySectionEl && historySectionEl.hidden){
+      return;
+    }
+
+    let points = valid;
+    const MAX_POINTS = 500;
+    if(points.length > MAX_POINTS){
+      const step = (points.length - 1) / (MAX_POINTS - 1);
+      const reduced = [];
+      for(let i = 0; i < MAX_POINTS; i++){
+        const idx = Math.round(i * step);
+        reduced.push(points[Math.min(idx, points.length - 1)]);
+      }
+      points = reduced;
     }
 
     const ctx = canvas.getContext("2d");
@@ -1357,12 +1647,13 @@
     }
     ctx.clearRect(0, 0, width, height);
 
-    if(!valid.length){
+    if(!points.length){
       return;
     }
 
-    const min = Math.min(...valid.map(pt => pt.p));
-    const max = Math.max(...valid.map(pt => pt.p));
+    const values = points.map(pt => Number(pt.p));
+    const min = Math.min(...values);
+    const max = Math.max(...values);
     const range = max - min || 1;
 
     const padX = 6 * dpr;
@@ -1370,10 +1661,10 @@
     const innerW = Math.max(1, width - padX * 2);
     const innerH = Math.max(1, height - padY * 2);
 
-    const coords = valid.map((pt, idx) => {
-      const x = (valid.length === 1)
+    const coords = points.map((pt, idx) => {
+      const x = (points.length === 1)
         ? padX + innerW / 2
-        : padX + (innerW * idx) / (valid.length - 1);
+        : padX + (innerW * idx) / (points.length - 1);
       const norm = (pt.p - min) / range;
       const y = padY + innerH - (innerH * norm);
       return { x, y };
@@ -1409,6 +1700,27 @@
       ctx.fillStyle = strokeColor;
       ctx.fill();
     }
+  }
+
+  document.querySelectorAll(".history-tab").forEach(btn => {
+    btn.addEventListener("click", () => {
+      const id = btn.getAttribute("data-history-range");
+      const win = id ? getHistoryWindowById(id) : null;
+      if(!win || win.id === historyWindowId) return;
+      historyWindowId = win.id;
+      try{ localStorage.setItem(HISTORY_WINDOW_KEY, historyWindowId); }catch{}
+      updateHistoryTabs();
+      renderSparkline();
+    });
+  });
+
+  if(historyToggleBtn){
+    historyToggleBtn.addEventListener("click", () => {
+      historyVisible = !historyVisible;
+      try{ localStorage.setItem(HISTORY_VISIBILITY_KEY, historyVisible ? "1" : "0"); }catch{}
+      applyHistoryVisibility();
+      if(historyVisible) renderSparkline();
+    });
   }
 
   async function ensureAlertPermission(){


### PR DESCRIPTION
## Summary
- replace the inline sparkline box with a toggleable history panel that stays hidden until requested
- add range tabs, chart container, and stat cards to surface highs, lows, averages, change, sample count, and last update
- persist the history window and visibility preferences while filtering and downsampling the chart data when rendered

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d195444928832dbb435740db490a7a