### PR TITLE
Stop showing history preload toast

### DIFF
--- a/index.html
+++ b/index.html
@@ -2308,7 +2308,6 @@
       savePriceHistory();
     }catch(err){
       console.warn("Failed to preload historical prices:", stringifyError(err), err);
-      if(toastEl) showToast(t("history_preload_fail"));
     }
 
     renderHistorySection();


### PR DESCRIPTION
## Summary
- restore the English locale's history preload failure copy to its original English text
- stop displaying the preload failure toast so the error message is no longer shown in any language

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d704adaea0832d9a26267c092dbe13