### PR TITLE
Speed up installed app startup on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -2263,7 +2263,7 @@
   langSel.addEventListener("change", onLangChange);
 
   /* boot */
-  window.addEventListener("load", async () => {
+  function boot(){
     $("y").textContent = new Date().getFullYear();
 
     const toastEl = $("toast");
@@ -2302,19 +2302,41 @@
       }
     }catch{}
 
-    try{
-      const preloadPoints = await fetchHistoricalPrices();
-      mergePriceHistoryPoints(preloadPoints);
-      savePriceHistory();
-    }catch(err){
-      console.warn("Failed to preload historical prices:", stringifyError(err), err);
-    }
-
     renderHistorySection();
     renderPriceDelta();
 
     setAuto(true);
-  });
+  }
+
+  (function(){
+    const start = () => {
+      boot();
+
+      const loadHistory = async () => {
+        try{
+          const preloadPoints = await fetchHistoricalPrices();
+          mergePriceHistoryPoints(preloadPoints);
+          savePriceHistory();
+          renderHistorySection();
+          renderPriceDelta();
+        }catch(err){
+          console.warn("Failed to preload historical prices:", stringifyError(err), err);
+        }
+      };
+
+      if('requestIdleCallback' in window){
+        requestIdleCallback(loadHistory, { timeout: 2000 });
+      }else{
+        setTimeout(loadHistory, 0);
+      }
+    };
+
+    if(document.readyState === "loading"){
+      document.addEventListener("DOMContentLoaded", start, { once: true });
+    }else{
+      start();
+    }
+  })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- initialize the UI on DOMContentLoaded instead of waiting for the full load event
- defer historical price preloading until idle time so cached data can render instantly
- refresh history widgets again after the deferred preload completes

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d78f0bbb00832db086e10bfbde6cc9