### PR TITLE
Update USD per ounce label text

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@
 
       <div class="spot-toolbar" style="display:flex;flex-wrap:wrap;gap:10px;align-items:flex-end">
         <div class="priceField" style="flex:1 1 180px;min-width:170px">
-          <label data-i18n="usd_oz_label">USD/oz (إدخال يدوي)</label>
+          <label data-i18n="usd_oz_label">USD/oz</label>
           <input id="oz" class="num" type="tel" inputmode="decimal" data-ph="oz_placeholder" placeholder="مثال: 2350" value="">
         </div>
 
@@ -684,7 +684,7 @@
       hdr_title:"أسعار الذهب — 18 قيراط و 21 قيراط (دولار/غرام)",
       hdr_hint:"حاليًا نحدّث السعر تلقائيًا كل {label}. إذا أردت الإدخال يدويًا، أوقف التحديث التلقائي ثم اكتب سعر الأونصة.",
       h_ounce:"سعر الأونصة بالدولار",
-      usd_oz_label:"USD/oz (إدخال يدوي)",
+      usd_oz_label:"USD/oz",
       oz_placeholder:"مثال: 2350",
       btn_refresh:"تحديث • Refresh",
       auto_title:"تحديث تلقائي كل {label}",
@@ -797,7 +797,7 @@
       hdr_title:"Gold Prices — 18K & 21K (USD/gram)",
       hdr_hint:"We auto-refresh every {label}. To enter manually, turn off auto-refresh, then type the ounce price.",
       h_ounce:"Ounce Price (USD)",
-      usd_oz_label:"USD/oz (manual input)",
+      usd_oz_label:"USD/oz",
       oz_placeholder:"e.g. 2350",
       btn_refresh:"Refresh",
       auto_title:"Auto refresh every {label}",


### PR DESCRIPTION
## Summary
- remove the manual input note from the USD/oz label in the interface
- update Arabic and English locale strings so both languages show the simplified label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7abf496fc832d9581378bbcc97b00