### PR TITLE
Fix responsive AdSense slot on larger screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,8 +182,11 @@
   /* coin image */
   .coin-img{display:block;width:500px;max-width:100%;height:auto;margin:6px auto;border-radius:10px;border:1px solid color-mix(in oklab, var(--gold) 25%, transparent);background:#0b0b0b;box-shadow:0 6px 16px rgba(0,0,0,.35);object-fit:contain}
   html[data-theme="light"] .coin-img{background:#f1f1f1;border-color:#e0e0e0}
- .ad-card figure{margin:0;display:flex;flex-direction:column;align-items:center;gap:10px;text-align:center}
+  .ad-card figure{margin:0;display:flex;flex-direction:column;align-items:center;gap:10px;text-align:center}
   .ad-card video{width:100%;max-width:320px;border-radius:12px;border:1px solid color-mix(in oklab, var(--gold) 22%, transparent);box-shadow:0 6px 16px rgba(0,0,0,.35)}
+  .ad-container{display:flex;justify-content:center;margin-top:10px}
+  .ad-slot{display:block;width:100%;min-height:280px}
+  @media(min-width:900px){.ad-slot{max-width:468px;margin:0 auto}}
   /* compact boxes */
   #coin{white-space:normal;line-height:1.25;padding:6px 8px}
   #coin .prices{gap:2px 10px}
@@ -472,15 +475,14 @@
 
  <section class="card" style="text-align:center; padding:20px 12px">
     <h2 data-i18n="ad_space_title">مساحة إعلانية</h2>
-    <ins class="adsbygoogle"
-         style="display:block"
-         data-ad-format="fluid"
-         data-ad-layout-key="-5f+bp-1l-1i+tr"
-         data-ad-client="ca-pub-4797992845421121"
-         data-ad-slot="2193382327"></ins>
-    <script>
-      (adsbygoogle = window.adsbygoogle || []).push({});
-    </script>
+    <div class="ad-container">
+      <ins class="adsbygoogle ad-slot"
+           style="display:block"
+           data-ad-client="ca-pub-4797992845421121"
+           data-ad-slot="2193382327"
+           data-ad-format="auto"
+           data-full-width-responsive="true"></ins>
+    </div>
   </section>
 
   <!-- Totals -->
@@ -642,6 +644,7 @@
      Helpers
      ========================= */
   const outRefs = {};
+  let adSlotInitialized = false;
   function bindOutputs(){ ["s18","b18","s21","b21","coinSell","coinBuy"].forEach(id => outRefs[id] = document.getElementById(id)); }
   function setOut(id, val){ if(outRefs[id]) outRefs[id].textContent = fmt(val); }
 
@@ -2207,6 +2210,26 @@
   })();
 
   /* PWA */
+  function initAdSenseSlot(){
+    const adEl = document.querySelector('.adsbygoogle');
+    if(!adEl || adSlotInitialized) return;
+    adSlotInitialized = true;
+
+    const pushAd = () => {
+      try{
+        (window.adsbygoogle = window.adsbygoogle || []).push({});
+      }catch(err){
+        console.warn('AdSense init failed:', err);
+      }
+    };
+
+    if(document.readyState === 'complete'){
+      pushAd();
+    }else{
+      window.addEventListener('load', pushAd, { once: true });
+    }
+  }
+
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register('/sw.js').catch(()=>{});
@@ -2256,6 +2279,7 @@
 
     applyTheme();
     applyI18n();
+    initAdSenseSlot();
 
     initHistoryToggle();
 


### PR DESCRIPTION
## Summary
- replace the fluid Google AdSense embed with a responsive auto layout wrapped in a constrained container
- add CSS to size the ad slot consistently on desktop and tablet breakpoints
- initialize the ad slot after load to ensure adsbygoogle is pushed exactly once

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_b_68e4c03fbec4832ab367b46ab6a428c1